### PR TITLE
fix windows can't download

### DIFF
--- a/download-frp.js
+++ b/download-frp.js
@@ -4,14 +4,18 @@ const downloadFile = require("./download-file")
 const path = require("path")
 const fs = require("fs")
 const tar = require("tar")
-
+const compressing = require("compressing")
 const getJSON = bent("json", {
   "User-Agent": "seveibar, frpc-bin (an npm module)",
 })
 
 const platform = os.platform()
-const arch = os.arch()
+
+let arch = os.arch()
 let osRelease = null
+
+if(arch == "x64") arch = "amd64";
+else if(arch == "x32") arch = "386";
 
 switch (platform) {
   case "win32":
@@ -74,10 +78,19 @@ module.exports = async () => {
   // e.g. download something like frpc-ubuntu.tar.xz
 
   const downloadPath = path.resolve(__dirname, myAsset.name)
-  const extractDirPath = path.resolve(
-    __dirname,
-    myAsset.name.replace(".tar.gz", "")
-  )
+  let extractDirPath;
+  if(arch == "amd64" || arch =="386"){
+    extractDirPath = path.resolve(
+      __dirname,
+      myAsset.name.replace(".zip", "")
+    )
+  }else{
+    extractDirPath = path.resolve(
+      __dirname,
+      myAsset.name.replace(".tar.gz", "")
+    )
+  }
+
   const frpcPath = path.resolve(extractDirPath, "frpc")
   const frpsPath = path.resolve(extractDirPath, "frps")
 
@@ -101,10 +114,16 @@ module.exports = async () => {
   if (!fs.existsSync(extractDirPath)) {
     console.log(`extracting ${myAsset.name}...`)
     let tarXPath = downloadPath
-    await tar.x({
-      file: tarXPath,
-      z: true,
-    })
+
+    if(arch == "amd64" || arch =="386"){
+      await compressing.zip.uncompress(`${extractDirPath}.zip`,__dirname);
+    }else{
+      await tar.x({
+        file: tarXPath,
+        z: true,
+      })
+    }
+
     fs.unlinkSync(tarXPath)
 
     if (!fs.existsSync(frpcPath)) {

--- a/download-frp.js
+++ b/download-frp.js
@@ -11,15 +11,12 @@ const getJSON = bent("json", {
 
 const platform = os.platform()
 
-let arch = os.arch()
+const arch = os.arch()
 let osRelease = null
-
-if(arch == "x64") arch = "amd64";
-else if(arch == "x32") arch = "386";
 
 switch (platform) {
   case "win32":
-    osRelease = `windows_${arch}`
+    osRelease = `windows_${arch.replace("x64", "amd64").replace("x32", "386")}`
     break
   case "darwin":
     osRelease = "darwin_amd64"
@@ -79,7 +76,7 @@ module.exports = async () => {
 
   const downloadPath = path.resolve(__dirname, myAsset.name)
   let extractDirPath;
-  if(arch == "amd64" || arch =="386"){
+  if(platform == "win32"){
     extractDirPath = path.resolve(
       __dirname,
       myAsset.name.replace(".zip", "")
@@ -115,7 +112,7 @@ module.exports = async () => {
     console.log(`extracting ${myAsset.name}...`)
     let tarXPath = downloadPath
 
-    if(arch == "amd64" || arch =="386"){
+    if(platform == "win32"){
       await compressing.zip.uncompress(`${extractDirPath}.zip`,__dirname);
     }else{
       await tar.x({

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "decompress-tar": "^4.1.1",
     "follow-redirects": "^1.13.0",
     "tar": "^6.0.5",
-    "tmp": "^0.2.1"
+    "tmp": "^0.2.1",
+    "compressing": "^1.5.1"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^8.0.1",


### PR DESCRIPTION
when I install node-frp2,He pops up the following error.So I change x64 to 386 and amd64.

npm ERR! Error: Couldn't find frp version compatible with windows_x64,
npm ERR!
npm ERR! Available releases:
npm ERR!        * frp_0.37.0_darwin_amd64.tar.gz
npm ERR!        * frp_0.37.0_darwin_arm64.tar.gz
npm ERR!        * frp_0.37.0_freebsd_386.tar.gz
npm ERR!        * frp_0.37.0_freebsd_amd64.tar.gz
npm ERR!        * frp_0.37.0_linux_386.tar.gz
npm ERR!        * frp_0.37.0_linux_amd64.tar.gz
npm ERR!        * frp_0.37.0_linux_arm.tar.gz
npm ERR!        * frp_0.37.0_linux_arm64.tar.gz
npm ERR!        * frp_0.37.0_linux_mips.tar.gz
npm ERR!        * frp_0.37.0_linux_mips64.tar.gz
npm ERR!        * frp_0.37.0_linux_mips64le.tar.gz
npm ERR!        * frp_0.37.0_linux_mipsle.tar.gz
npm ERR!        * frp_0.37.0_windows_386.zip
npm ERR!        * frp_0.37.0_windows_amd64.zip
npm ERR!     at module.exports (C:\test\node_modules\node-frp2\download-frp.js:66:11)
npm ERR!     at processTicksAndRejections (node:internal/process/task_queues:96:5)